### PR TITLE
Fix youtube regex in Repetition chapter

### DIFF
--- a/chapters/repetition.mdx
+++ b/chapters/repetition.mdx
@@ -177,7 +177,7 @@ Here, this could also be achieved by using `[^"]` instead of `.` (as is best pra
 
 <Example
     regex={
-        /^(?:https?:\/\/)?(?:www\.?)?youtube\.com\/watch\?.*?v=([^&\s]+).*$/gm
+        /^(?:https?:\/\/)?(?:www\.)?youtube\.com\/watch\?.*?v=([^&\s]+).*$/gm
     }
 >
     <li>youtube.com/watch?feature=sth&v=dQw4w9WgXcQ</li>


### PR DESCRIPTION
making the dot optional after www allows a url like wwwyoutube to pass. This pr fixes it.